### PR TITLE
Signals at buffer stops and derailers

### DIFF
--- a/signals.mml
+++ b/signals.mml
@@ -390,7 +390,7 @@ Layer:
             tags->'railway:signal:whistle:type' AS whistle_type
           FROM openrailwaymap_osm_signals
           WHERE
-            railway = 'signal'
+            railway IN ('signal', 'buffer_stop', 'derail')
             AND "signal_direction" IS NOT NULL
           ORDER BY
             -- distant signals are less important, signals for slower speeds are more important

--- a/signals.mml
+++ b/signals.mml
@@ -390,8 +390,8 @@ Layer:
             tags->'railway:signal:whistle:type' AS whistle_type
           FROM openrailwaymap_osm_signals
           WHERE
-            railway IN ('signal', 'buffer_stop', 'derail')
-            AND "signal_direction" IS NOT NULL
+            (railway IN ('signal', 'buffer_stop') AND "signal_direction" IS NOT NULL)
+            OR railway = 'derail'
           ORDER BY
             -- distant signals are less important, signals for slower speeds are more important
             (CASE

--- a/signals.mss
+++ b/signals.mss
@@ -367,31 +367,29 @@ Format details:
   /************************************************/
   /* DE minor semaphore signals and signs type Sh */
   /************************************************/
-  [zoom>=17]["feature"="DE-ESO:sh"] {
-    ["minor_form"="semaphore"],
-    ["minor_form"="sign"] {
-      marker-file: url('symbols/de/sh0-semaphore-dwarf.svg');
-      marker-width: 12;
-      marker-height: 11;
+  [zoom>=17]["feature"="DE-ESO:sh"]["minor_form"="semaphore"],
+  [zoom>=17]["feature"="DE-ESO:sh0"]["minor_form"="sign"] {
+    marker-file: url('symbols/de/sh0-semaphore-dwarf.svg');
+    marker-width: 12;
+    marker-height: 11;
+    marker-allow-overlap: true;
+
+    ::text {
+      text-name: [ref];
+      text-dy: 11;
+      text-fill: @signal-text-fill;
+      text-halo-radius: @signal-text-halo-radius;
+      text-halo-fill: @signal-text-halo-fill;
+      text-face-name: @bold-fonts;
+      text-size: 10;
+    }
+
+    ["minor_form"="semaphore"]["minor_height"="normal"],
+    ["minor_form"="semaphore"]["minor_height"=null] {
+      marker-file: url('symbols/de/sh1-semaphore-normal.svg');
+      marker-width: 10;
+      marker-height: 12;
       marker-allow-overlap: true;
-
-      ::text {
-        text-name: [ref];
-        text-dy: 11;
-        text-fill: @signal-text-fill;
-        text-halo-radius: @signal-text-halo-radius;
-        text-halo-fill: @signal-text-halo-fill;
-        text-face-name: @bold-fonts;
-        text-size: 10;
-      }
-
-      ["minor_form"="semaphore"]["minor_height"="normal"],
-      ["minor_form"="semaphore"]["minor_height"=null] {
-        marker-file: url('symbols/de/sh1-semaphore-normal.svg');
-        marker-width: 10;
-        marker-height: 12;
-        marker-allow-overlap: true;
-      }
     }
   }
 


### PR DESCRIPTION
Fixes #16.

Changes:

* render all signals at derailers and buffer stops
* do not require `railway:signal:direction` at derailers.
* German signal Sh 0 as sign is tagged `railway:signal:minor=DE-ESO:sh0`, not `railway:signal:minor=DE-ESO:sh`.