### PR TITLE
Render at least ref=* or name=* if one of the two is NULL

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -508,10 +508,12 @@ Layer:
                  WHEN railway = 'disused' THEN 300
                  WHEN railway = 'abandoned' THEN 250
                  WHEN railway = 'razed' THEN 200
-
                  ELSE 50
             END AS rank,
-            ref || ' ' || railway_label_name(name, tags, tunnel, bridge) AS label
+            CASE
+              WHEN ref IS NOT NULL AND label_name IS NOT NULL THEN ref || ' ' || label_name
+              ELSE COALESCE(ref, label_name)
+            END AS label
           FROM
             (SELECT
                 way, railway, usage, service, tags->'highspeed' AS highspeed,
@@ -521,6 +523,7 @@ Layer:
                 tags->'proposed:railway' AS proposed_railway,
                 tags, tunnel, bridge,
                 name, ref,
+                railway_label_name(name, tags, tunnel, bridge) AS label_name,
                 z_order
               FROM openrailwaymap_osm_line
               WHERE
@@ -622,10 +625,12 @@ Layer:
                  WHEN railway = 'disused' THEN 300
                  WHEN railway = 'abandoned' THEN 250
                  WHEN railway = 'razed' THEN 200
-
                  ELSE 50
             END AS rank,
-            ref || ' ' || railway_label_name(name, tags, tunnel, bridge) AS label,
+            CASE
+              WHEN ref IS NOT NULL AND label_name IS NOT NULL THEN ref || ' ' || label_name
+              ELSE COALESCE(ref, label_name)
+            END AS label,
             track_ref
           FROM
             (SELECT
@@ -638,6 +643,7 @@ Layer:
                 name, ref,
                 tags->'railway:track_ref' AS track_ref,
                 tunnel, bridge,
+                railway_label_name(name, tags, tunnel, bridge) AS label_name,
                 z_order
               FROM openrailwaymap_osm_line
               WHERE


### PR DESCRIPTION
On zoom level 15 and above the route number and/or name was only rendered if both were tagged because the string concatenation using `||` returns NULL if any of the strings to be concatenated is null. This affects the railway_text_high and railway_text_detail layers.

Before:
![before](https://user-images.githubusercontent.com/3611273/82046387-10980f00-96b1-11ea-98d8-7458f669d9e6.png)

After:
![after](https://user-images.githubusercontent.com/3611273/82046384-0fff7880-96b1-11ea-83b1-067ad02a7e02.png)

Location: https://www.openrailwaymap.org/?lang=null&lat=49.0009130690859&lon=8.42961698770523&zoom=18&style=standard
