### PR TITLE
Render station=subway/light_rail in italic font

### DIFF
--- a/standard_labels.mss
+++ b/standard_labels.mss
@@ -56,6 +56,10 @@
     [railway = 'halt'] {
       text-fill: @text-station-color;
       text-halo-fill: @text-station-halo-color;
+      [station = 'light_rail'],
+      [station = 'subway'] {
+        text-face-name: @oblique-fonts;
+      }
     }
     [railway = 'tram_stop'] {
       text-fill: @text-tram-stop-color;


### PR DESCRIPTION
Reimplementation of https://github.com/OpenRailwayMap/OpenRailwayMap/pull/629 in CartoCSS