### PR TITLE
Add 4th_rail to electrification valid_values

### DIFF
--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -359,7 +359,7 @@ CREATE OR REPLACE FUNCTION railway_electrification_state(railway TEXT, electrifi
   proposed_electrified TEXT, ignore_future_states BOOLEAN) RETURNS TEXT AS $$
 DECLARE
   state TEXT;
-  valid_values TEXT[] := ARRAY['contact_line', 'yes', 'rail', 'ground-level_power_supply', 'contact_line;rail', 'rail;contact_line'];
+  valid_values TEXT[] := ARRAY['contact_line', 'yes', 'rail', 'ground-level_power_supply', '4th_rail', 'contact_line;rail', 'rail;contact_line'];
 BEGIN
   state := NULL;
   IF electrified = ANY(valid_values) THEN


### PR DESCRIPTION
Per [documentation of key:electrified on OSM](https://wiki.openstreetmap.org/wiki/Key:electrified?uselang=en).

Should fix issue of the London Underground displaying as gray lines on the electrification style. (Milan Line M1 I read also uses fourth rail, but isn't tagged as such on OSM.)