### PR TITLE
 add "Zs3 ?" and "Zs3v ?" icons #51 

### DIFF
--- a/maxspeed_signals.mss
+++ b/maxspeed_signals.mss
@@ -200,6 +200,9 @@
     }
     
     /* German speed signals (Zs 3) as signs*/
+    ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="sign"]["signal_speed_limit_speed"=null] {
+      marker-file: url('symbols/de/zs3-empty-sign-down.svg');
+    }
     ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="sign"] {
       ["signal_speed_limit_speed"=~"^(1[0-6]|[1-9])0$"] {
         marker-allow-overlap: true;
@@ -257,6 +260,10 @@
     }
 
     /* German speed signals (Zs 3) as light signals*/
+    ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="light"]["signal_speed_limit_speed"=null],
+    ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="light"]["signal_speed_limit_speed"="^off,\?$"] {
+      marker-file: url('symbols/de/zs2-unknown.svg'); /* for light signals: empty Zs3 "looks" exactly like empty Zs2 */
+    }
     ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="light"] {
       ["signal_speed_limit_speed"=~"^(1[0-2]|[2-9])0$"] {
         marker-width: 14;

--- a/maxspeed_signals.mss
+++ b/maxspeed_signals.mss
@@ -18,6 +18,9 @@
     }
     
     /* German speed signals (Zs 3v) as signs */
+    ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="sign"]["signal_speed_limit_distant_speed"=null] {
+      marker-file: url('symbols/de/zs3v-empty-sign-down.svg');
+    }
     ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="sign"] {
       ["signal_speed_limit_distant_speed"=~"^(1[0-6]|[1-9])0$"] {
         marker-allow-overlap: true;
@@ -72,6 +75,11 @@
     }
 
     /* German speed signals (Zs 3v) as light signals */
+    ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="light"]["signal_speed_limit_distant_speed"=null],
+    ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="light"]["signal_speed_limit_distant_speed"="^off,\?$"] {
+      marker-file: url('symbols/de/zs2v-unknown.svg'); /* for light signals: empty Zs3v "looks" exactly like empty Zs2v*/
+    }
+
     ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="light"] {
       ["signal_speed_limit_distant_speed"=~"^(1[0-2]|[2-9])0$"] {
         marker-allow-overlap: true;

--- a/maxspeed_signals.mss
+++ b/maxspeed_signals.mss
@@ -18,10 +18,13 @@
     }
     
     /* German speed signals (Zs 3v) as signs */
-    ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="sign"]["signal_speed_limit_distant_speed"=null] {
-      marker-file: url('symbols/de/zs3v-empty-sign-down.svg');
-    }
     ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="sign"] {
+      ["signal_speed_limit_distant_speed"=null] {
+        marker-file: url('symbols/de/zs3v-empty-sign-down.svg');
+        marker-width: 22;
+        marker-height: 19;
+        marker-allow-overlap: true;
+      }
       ["signal_speed_limit_distant_speed"=~"^(1[0-6]|[1-9])0$"] {
         marker-allow-overlap: true;
         marker-width: 22;
@@ -75,12 +78,14 @@
     }
 
     /* German speed signals (Zs 3v) as light signals */
-    ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="light"]["signal_speed_limit_distant_speed"=null],
-    ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="light"]["signal_speed_limit_distant_speed"="^off,\?$"] {
-      marker-file: url('symbols/de/zs2v-unknown.svg'); /* for light signals: empty Zs3v "looks" exactly like empty Zs2v*/
-    }
-
     ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="light"] {
+      ["signal_speed_limit_distant_speed"=null],
+      ["signal_speed_limit_distant_speed"="^off;\?$"] {
+        marker-file: url('symbols/de/zs2v-unknown.svg'); /* for light signals: empty Zs3v "looks" exactly like empty Zs2v*/
+        marker-allow-overlap: true;
+        marker-width: 14;
+        marker-height: 19;
+      }
       ["signal_speed_limit_distant_speed"=~"^(1[0-2]|[2-9])0$"] {
         marker-allow-overlap: true;
         marker-width: 14;
@@ -200,10 +205,13 @@
     }
     
     /* German speed signals (Zs 3) as signs*/
-    ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="sign"]["signal_speed_limit_speed"=null] {
-      marker-file: url('symbols/de/zs3-empty-sign-down.svg');
-    }
     ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="sign"] {
+      ["signal_speed_limit_speed"=null] {
+        marker-file: url('symbols/de/zs3-empty-sign-down.svg');
+        marker-allow-overlap: true;
+        marker-width: 22;
+        marker-height: 19;
+      }
       ["signal_speed_limit_speed"=~"^(1[0-6]|[1-9])0$"] {
         marker-allow-overlap: true;
         marker-width: 22;
@@ -260,11 +268,14 @@
     }
 
     /* German speed signals (Zs 3) as light signals*/
-    ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="light"]["signal_speed_limit_speed"=null],
-    ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="light"]["signal_speed_limit_speed"="^off,\?$"] {
-      marker-file: url('symbols/de/zs2-unknown.svg'); /* for light signals: empty Zs3 "looks" exactly like empty Zs2 */
-    }
     ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="light"] {
+      ["signal_speed_limit_speed"=null],
+      ["signal_speed_limit_speed"="^off;\?$"] {
+        marker-file: url('symbols/de/zs2-unknown.svg'); /* for light signals: empty Zs3 "looks" exactly like empty Zs2 */
+        marker-width: 14;
+        marker-height: 19;
+        marker-allow-overlap: true;
+      }
       ["signal_speed_limit_speed"=~"^(1[0-2]|[2-9])0$"] {
         marker-width: 14;
         marker-height: 19;

--- a/maxspeed_signals.mss
+++ b/maxspeed_signals.mss
@@ -19,16 +19,14 @@
     
     /* German speed signals (Zs 3v) as signs */
     ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="sign"] {
-      ["signal_speed_limit_distant_speed"=null] {
-        marker-file: url('symbols/de/zs3v-empty-sign-down.svg');
+      ["signal_speed_limit_distant_speed"=null],
+      ["signal_speed_limit_distant_speed"=~"^(1[0-6]|[1-9])0$"] {
         marker-width: 22;
         marker-height: 19;
         marker-allow-overlap: true;
       }
-      ["signal_speed_limit_distant_speed"=~"^(1[0-6]|[1-9])0$"] {
-        marker-allow-overlap: true;
-        marker-width: 22;
-        marker-height: 19;
+      ["signal_speed_limit_distant_speed"=null] {
+        marker-file: url('symbols/de/zs3v-empty-sign-down.svg');
       }
       ["signal_speed_limit_distant_speed"="10"] {
         marker-file: url('symbols/de/zs3v-10-sign-down.svg');
@@ -80,16 +78,15 @@
     /* German speed signals (Zs 3v) as light signals */
     ["feature"="DE-ESO:zs3v"]["signal_speed_limit_distant_form"="light"] {
       ["signal_speed_limit_distant_speed"=null],
-      ["signal_speed_limit_distant_speed"="^off;\?$"] {
-        marker-file: url('symbols/de/zs2v-unknown.svg'); /* for light signals: empty Zs3v "looks" exactly like empty Zs2v*/
-        marker-allow-overlap: true;
-        marker-width: 14;
-        marker-height: 19;
-      }
+      ["signal_speed_limit_distant_speed"="^off;\?$"], 
       ["signal_speed_limit_distant_speed"=~"^(1[0-2]|[2-9])0$"] {
         marker-allow-overlap: true;
         marker-width: 14;
         marker-height: 19;
+      }
+      ["signal_speed_limit_distant_speed"=null],
+      ["signal_speed_limit_distant_speed"="^off;\?$"] {
+        marker-file: url('symbols/de/zs2v-unknown.svg'); /* for light signals: empty Zs3v "looks" exactly like empty Zs2v*/
       }
       ["signal_speed_limit_distant_speed"="20"] {
         marker-file: url('symbols/de/zs3v-20-light.svg');
@@ -204,18 +201,16 @@
       }
     }
     
-    /* German speed signals (Zs 3) as signs*/
+    /* German speed signals (Zs 3) as signs */
     ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="sign"] {
+      ["signal_speed_limit_speed"=~"^(1[0-6]|[1-9])0$"],
       ["signal_speed_limit_speed"=null] {
-        marker-file: url('symbols/de/zs3-empty-sign-down.svg');
         marker-allow-overlap: true;
         marker-width: 22;
         marker-height: 19;
       }
-      ["signal_speed_limit_speed"=~"^(1[0-6]|[1-9])0$"] {
-        marker-allow-overlap: true;
-        marker-width: 22;
-        marker-height: 19;
+      ["signal_speed_limit_speed"=null] {
+        marker-file: url('symbols/de/zs3-empty-sign-up.svg');
       }
       ["signal_speed_limit_speed"="10"] {
         marker-file: url('symbols/de/zs3-10-sign-up.svg');
@@ -267,19 +262,18 @@
       }
     }
 
-    /* German speed signals (Zs 3) as light signals*/
+    /* German speed signals (Zs 3) as light signals */
     ["feature"="DE-ESO:zs3"]["signal_speed_limit_form"="light"] {
       ["signal_speed_limit_speed"=null],
-      ["signal_speed_limit_speed"="^off;\?$"] {
-        marker-file: url('symbols/de/zs2-unknown.svg'); /* for light signals: empty Zs3 "looks" exactly like empty Zs2 */
-        marker-width: 14;
-        marker-height: 19;
-        marker-allow-overlap: true;
-      }
+      ["signal_speed_limit_speed"="^off;\?$"],
       ["signal_speed_limit_speed"=~"^(1[0-2]|[2-9])0$"] {
         marker-width: 14;
         marker-height: 19;
         marker-allow-overlap: true;
+      }
+      ["signal_speed_limit_speed"=null],
+      ["signal_speed_limit_speed"="^off;\?$"] {
+        marker-file: url('symbols/de/zs2-unknown.svg'); /* for light signals: empty Zs3 "looks" exactly like empty Zs2 */
       }
       ["signal_speed_limit_speed"="20"] {
         marker-file: url('symbols/de/zs3-20-light.svg');


### PR DESCRIPTION
This PR adds Zs 3 ? and Zs 3v ? to the mss file. Icons were already in the symbols directory.
Maybe it could be nice to have a different rendering of unknown/empty light signals Zs 2(v) and Zs 3(v) through a triangular (Zs3(v)) or squared (Zs2(v)) box?
This PR resolves issue #51 