### PR TITLE
render signal_box at zoom 11/12 as point w/o text

### DIFF
--- a/signal_boxes.mss
+++ b/signal_boxes.mss
@@ -13,7 +13,7 @@
   line-width: 1;
 }
 
-#signal_boxes_point[zoom>=13] {
+#signal_boxes_point[zoom>=11] {
   /* render a circle, therefore marker-file is not set */
   marker-fill: @signal_box_color;
   marker-line-width: 1;

--- a/signals.mml
+++ b/signals.mml
@@ -235,7 +235,7 @@ Layer:
           ) AS boxes
         ) AS signal_boxes_point
     properties:
-      minzoom: 13
+      minzoom: 11
   - id: signal_boxes_polygon
     geometry: polygon
     <<: *extents


### PR DESCRIPTION
This PR resolves issue #9 . I dont think that it's necessary to have text as it would be crowded on the map. 