### PR TITLE
Render dashed lines for all railways under construction in the electrification layer

### DIFF
--- a/electrification.mss
+++ b/electrification.mss
@@ -153,6 +153,11 @@
     ["state"="construction"][zoom < 9] {
        line-color: black;
     }
+    
+    ["state"=null]["railway"="construction"]
+    {
+    	line-color: darkgrey;
+    }
 
     ["state"="deelectrified"],
     ["state"="abandoned"] {
@@ -160,7 +165,8 @@
     }
 
     #electrification_future {
-      ["state"="construction"] {
+      ["state"="construction"],
+      ["railway"="construction"] {
         line-dasharray: @construction-dashes;
       }
 
@@ -209,7 +215,7 @@
        line-color: #97FF2F;
     }
 
-    [frequency=null][frequency!=0][voltage>=15000][voltage<25000] {
+    [frequency!=null][frequency!=0][voltage>=15000][voltage<25000] {
        line-color: #F1F100;
     }
 
@@ -221,7 +227,7 @@
        line-color: #00CB66;
     }
 
-    [frequency=null][frequency!=0][voltage>=25000] {
+    [frequency!=null][frequency!=0][voltage>25000] {
        line-color: #FF9F19;
     }
 

--- a/electrification.mss
+++ b/electrification.mss
@@ -22,6 +22,8 @@
 @color_25kv_50: #FF0000;
 @color_25kv_60: #C00000;
 
+@construct_elec_unknown: darkgrey;
+
 /**
   * Railway tracks with electrification under construction or proposed electrification
   * are rendered with a second symbolizer called proposed_construction.
@@ -151,13 +153,9 @@
     ["state"="no"],
     ["state"="proposed"][zoom < 9],
     ["state"="construction"][zoom < 9] {
-       line-color: black;
+       line-color: @color_no;
     }
     
-    ["state"=null]["railway"="construction"]
-    {
-    	line-color: darkgrey;
-    }
 
     ["state"="deelectrified"],
     ["state"="abandoned"] {
@@ -173,6 +171,14 @@
       ["state"="proposed"] {
         line-dasharray: @proposed-dashes;
       }
+    }
+    /* When this layer runs, if the line is under construction
+     * and doesn't have an explicit electrified=no/construction:electrified=no
+     * render a light grey/dark grey mix until a voltage color overrides */
+    #electrification_future {
+      ["railway"="construction"]["state"!="no"] {
+       line-color: @construct_elec_unknown;
+       }
     }
 
     [frequency=0]["voltage"<750] {

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -362,18 +362,27 @@ DECLARE
   valid_values TEXT[] := ARRAY['contact_line', 'yes', 'rail', 'ground-level_power_supply', '4th_rail', 'contact_line;rail', 'rail;contact_line'];
 BEGIN
   state := NULL;
+  IF NOT ignore_future_states AND construction_electrified = ANY(valid_values) THEN
+    RETURN 'construction';
+  END IF;    
+  IF NOT ignore_future_states AND railway = 'construction' AND construction_electrified = 'no' THEN
+    return 'no';
+  ELSIF NOT ignore_future_states AND railway = 'construction' THEN
+    return NULL;  
+  END IF;
+
+
+  IF NOT ignore_future_states AND proposed_electrified = ANY(valid_values) THEN
+    RETURN 'proposed';
+  END IF;  
   IF electrified = ANY(valid_values) THEN
     return 'present';
   END IF;
   IF electrified = 'no' THEN
     state := 'no';
   END IF;
-  IF NOT ignore_future_states AND construction_electrified = ANY(valid_values) THEN
-    RETURN 'construction';
-  END IF;
-  IF NOT ignore_future_states AND proposed_electrified = ANY(valid_values) THEN
-    RETURN 'proposed';
-  END IF;
+
+	
   IF state = 'no' AND deelectrified = ANY(valid_values) THEN
     RETURN 'deelectrified';
   END IF;

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -362,27 +362,24 @@ DECLARE
   valid_values TEXT[] := ARRAY['contact_line', 'yes', 'rail', 'ground-level_power_supply', '4th_rail', 'contact_line;rail', 'rail;contact_line'];
 BEGIN
   state := NULL;
-  IF NOT ignore_future_states AND construction_electrified = ANY(valid_values) THEN
-    RETURN 'construction';
-  END IF;    
-  IF NOT ignore_future_states AND railway = 'construction' AND construction_electrified = 'no' THEN
-    return 'no';
-  ELSIF NOT ignore_future_states AND railway = 'construction' THEN
-    return NULL;  
+-- For the first layer if this is construction, let the second pass do the work
+  IF ignore_future_states AND railway = 'construction' THEN
+    RETURN NULL;
   END IF;
-
-
-  IF NOT ignore_future_states AND proposed_electrified = ANY(valid_values) THEN
-    RETURN 'proposed';
-  END IF;  
   IF electrified = ANY(valid_values) THEN
     return 'present';
   END IF;
   IF electrified = 'no' THEN
     state := 'no';
   END IF;
-
-	
+  IF NOT ignore_future_states AND construction_electrified = ANY(valid_values) THEN
+    RETURN 'construction';
+  ELSIF NOT ignore_future_states AND railway = 'construction' AND construction_electrified = 'no' THEN
+    return 'no';
+  END IF;
+  IF NOT ignore_future_states AND proposed_electrified = ANY(valid_values) THEN
+    RETURN 'proposed';
+  END IF;
   IF state = 'no' AND deelectrified = ANY(valid_values) THEN
     RETURN 'deelectrified';
   END IF;


### PR DESCRIPTION
This PR fixes issue #47 where certain lines under construction show as completed lines in the electrification layer. I also addressed as a quick fix #42 but it is not as comprehensive as PR #57.

This wasn't a straightforward fix and required a bit of tweaking. We may also want to address the color scheme: the dashed pattern of grey and color for lines under construction does not render well on thinly weighted light rail lines.

Some of these issues were caused by poor or ambiguous tagging where there is a mix of regular (electrified,voltage,frequency) and `construction:` tags.  While some of these issues can be corrected in the project code, we should not attempt to become an AI bot and "do what the user meant." However, I will take advantage of certain fall throughs if they produce the desired result. An improper fall through in `railway_electrification_state()` [sql/functions.sql](../blob/master/sql/functions.sql) triggered several of the issues.  

Here are some of the behaviors I have documented:
1. [**OK**]  extant line, electrification upgrades under construction (`railway=rail`; `construction:electrification=rail/contact_line/4th_rail` => renders dashed line alternating between black and the assigned electrification color; example: [Caltrain San Francisco to San Jose](https://www.openrailwaymap.org/?style=electrified&lat=37.469246737714116&lon=-122.20658183097838&zoom=16)
2. [**OK**] line under construction, properly tagged construction:electrified/construction:voltage/construction:frequency => renders dashed grey + assigned electrification color; example: [here](https://www.openrailwaymap.org/?style=electrified&lat=45.20648803427833&lon=6.758286952972412&zoom=15) 
3. [**BAD!**] non-electrified line under construction, construction:electrified=no => renders as completed line/ambiguous electrification (solid grey); example: [NJ Transit Lackawanna Cut Off Expansion](https://www.openrailwaymap.org/?style=electrified&lat=40.95290460015215&lon=-74.70175266265869&zoom=14);  Desired behavior: render as dashed black.
4. [**BAD!**] electrified line under construction, electrified/voltage/frequency specified without `construction:` prefix => renders as a solid line in the as if the line were completed; example: the [Finland case](https://www.openrailwaymap.org/?style=electrified&lat=60.22936357183169&lon=24.91794168949127&zoom=17) in   Desired behavior: render as broken line with electrification colors (anticipating user needs) OR render as a dashed line without colorization indicating line is under construction. This could be corrected by fixing the tagging but I imagine we'll see many other ways with this style of tagging.  The example here was taken from OpenRailwayMap/OpenRailwayMap#718 
5.  [**BAD!**] line under construction, ambiguously tagged (e.g. `electrified=yes`) => renders as solid grey; example [here](https://www.openrailwaymap.org/?style=electrified&lat=19.39290029041924&lon=-99.19784590601921&zoom=19) We don't necessarily have a desired behavior for this, but the line should be dashed  In this PR I propose interleaving the current grey fill color with an additional `darkgrey` fill color to mix grey/darkgrey
6. around [Greenboro light rail station](https://www.openrailwaymap.org/?style=electrified&lat=45.35830104572409&lon=-75.65703213214873&zoom=17) renders solid black to the north of the station where it is fully tagged (`construction:railway=light_rail`; `construction=light_rail`; `railway=construction`)  but is also tagged `electrified=no`.  The line just south of the station has no electrification tagging and renders solid grey. Both lines should be dashed.


All 6 examples now render properly.