### PR TITLE
Add rendering for ZSI 127

### DIFF
--- a/signals.mml
+++ b/signals.mml
@@ -98,13 +98,14 @@ Layer:
             NULL AS construction_usage, NULL AS construction_service,
             NULL AS preserved_railway, NULL AS preserved_service,
             NULL AS preserved_usage,
-            pzb, lzb, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, etcs, construction_etcs,
-            railway_train_protection_rank(pzb, lzb, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, etcs, construction_etcs) AS rank
+            pzb, lzb, zsi127, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, etcs, construction_etcs,
+            railway_train_protection_rank(pzb, lzb, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, zsi127, etcs, construction_etcs) AS rank
           FROM
             (SELECT
                 way, railway, usage,
                 tags->'railway:pzb' AS pzb,
                 railway_null_to_no(tags->'railway:lzb') AS lzb,
+                tags->'railway:zsi127' as zsi127,
                 tags->'railway:atb' AS atb,
                 tags->'railway:atb-eg' AS atb_eg,
                 tags->'railway:atb-ng' AS atb_ng,
@@ -140,13 +141,14 @@ Layer:
             NULL AS construction_usage, NULL AS construction_service,
             NULL AS preserved_railway, NULL AS preserved_service,
             NULL AS preserved_usage,
-            pzb, lzb, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, etcs, construction_etcs,
-            railway_train_protection_rank(pzb, lzb, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, etcs, construction_etcs) AS rank
+            pzb, lzb, zsi127, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, etcs, construction_etcs,
+            railway_train_protection_rank(pzb, lzb, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, zsi127, etcs, construction_etcs) AS rank
           FROM
             (SELECT
                 way, railway, usage,
                 tags->'railway:pzb' AS pzb,
                 railway_null_to_no(tags->'railway:lzb') AS lzb,
+                tags->'railway:zsi127' AS zsi127,
                 tags->'railway:atb' AS atb,
                 tags->'railway:atb-eg' AS atb_eg,
                 tags->'railway:atb-ng' AS atb_ng,
@@ -182,8 +184,8 @@ Layer:
             construction_usage, construction_service,
             preserved_railway, preserved_service,
             preserved_usage,
-            pzb, lzb, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, etcs, construction_etcs,
-            railway_train_protection_rank(pzb, lzb, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, etcs, construction_etcs) AS rank
+            pzb, lzb, zsi127, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, etcs, construction_etcs,
+            railway_train_protection_rank(pzb, lzb, atb, atb_eg, atb_ng, atb_vv, atc, kvb, tvm, scmt, ptc, zsi127, etcs, construction_etcs) AS rank
           FROM
             (SELECT
                 way, railway, usage, service,
@@ -196,6 +198,7 @@ Layer:
                 tags->'preserved:usage' AS preserved_usage,
                 tags->'railway:pzb' AS pzb,
                 railway_null_to_no(tags->'railway:lzb') AS lzb,
+                tags->'railway:zsi127' AS zsi127,
                 tags->'railway:atb' AS atb,
                 tags->'railway:atb-eg' AS atb_eg,
                 tags->'railway:atb-ng' AS atb_ng,

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -319,6 +319,7 @@ CREATE OR REPLACE FUNCTION railway_train_protection_rank(
   tvm TEXT,
   scmt TEXT,
   ptc TEXT,
+  zsi127 TEXT,
   etcs TEXT,
   construction_etcs TEXT) RETURNS INTEGER AS $$
 BEGIN
@@ -346,13 +347,16 @@ BEGIN
   IF COALESCE(atb, atb_eg, atb_ng, atb_vv) = 'yes' THEN
     RETURN 4;
   END IF;
+  IF zsi127 = 'yes' THEN
+    RETURN 3;
+  END IF;
   IF lzb = 'yes' THEN
     RETURN 3;
   END IF;
   IF pzb = 'yes' THEN
     RETURN 2;
   END IF;
-  IF (pzb = 'no' AND lzb = 'no' AND etcs = 'no') OR (atb = 'no' AND etcs = 'no') OR (atc = 'no' AND etcs = 'no') OR (scmt = 'no' AND etcs = 'no') OR (kvb = 'no' AND tvm = 'no' AND etcs = 'no') THEN
+  IF (pzb = 'no' AND lzb = 'no' AND etcs = 'no') OR (atb = 'no' AND etcs = 'no') OR (atc = 'no' AND etcs = 'no') OR (scmt = 'no' AND etcs = 'no') OR (kvb = 'no' AND tvm = 'no' AND etcs = 'no') OR (zsi127 = 'no') THEN
     RETURN 1;
   END IF;
   RETURN 0;

--- a/train_protection.mss
+++ b/train_protection.mss
@@ -6,6 +6,7 @@
 @no_train_protection_color: black;
 @pzb_color: #ffb900;
 @lzb_color: red;
+@zsi127_color: #5c1ccb;
 @atb_color: #ff8c00;
 @atc_color: #6600cc;
 @scmt_color: #dd11ff;
@@ -99,6 +100,9 @@
     }
     ["ptc"!="no"] {
       line-color: @ptc_color;
+    }
+    ["zsi127"="yes"] {
+      line-color: @zsi127_color;
     }
 
     ["railway"="construction"] {


### PR DESCRIPTION
Adds rendering for ZSI 127, the narrow gauge train protection system that's being rolled out in Switzerland (sadly most information on it is only available in German, like at https://de.wikipedia.org/wiki/Zugsicherung_auf_Schmalspurbahnen_in_der_Schweiz#ZSI-127 ). I struggled quite a bit with choosing a color, so absolutely open to changing it.

The reason I chose to give it priority 3 is that there are technically "worse" narrow gauge train protection systems that are being used alongside ZSI 127 - though barely any of that is mapped. Further, on some three or four rail segments there might be ZSI 127 and ETCS available.