### PR TITLE
FIX: etcs=no prioritized over construction_etcs!=no (#91)

### DIFF
--- a/train_protection.mss
+++ b/train_protection.mss
@@ -57,10 +57,10 @@
   [zoom>=13]["railway"="light_rail"],
   [zoom>=11]["railway"="tram"]["service"=null],
   [zoom>=13]["railway"="tram"] {
-    ["pzb"="no"]["lzb"="no"]["etcs"="no"],
-    ["atb"="no"]["etcs"="no"],
-    ["kvb"="no"]["tvm"="no"]["etcs"="no"],
-    ["scmt"="no"]["etcs"="no"] {
+    ["pzb"="no"]["lzb"="no"]["etcs"="no"]["construction_etcs"="no"],
+    ["atb"="no"]["etcs"="no"]["construction_etcs"="no"],
+    ["kvb"="no"]["tvm"="no"]["etcs"="no"]["construction_etcs"="no"],
+    ["scmt"="no"]["etcs"="no"]["construction_etcs"="no"] {
       line-color: @no_train_protection_color;
     }
     ["pzb"="yes"] {


### PR DESCRIPTION
"construction_etcs=no" must be added as a condition for "line-color: @no_train_protection_color", otherwise that block always gets priority over "line-color: @etcs_construction_color" regardless of the order of the blocks.