### PR TITLE
MOD: delegate 'no signalling' logic from CSS to SQL

### DIFF
--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -307,6 +307,7 @@ $$ LANGUAGE plpgsql;
 
 
 -- Get rank by train protection a track is equipped with
+-- Other code expects 1 for no protection, 0 for default/unknown
 CREATE OR REPLACE FUNCTION railway_train_protection_rank(
   pzb TEXT,
   lzb TEXT,

--- a/train_protection.mss
+++ b/train_protection.mss
@@ -59,11 +59,7 @@
   [zoom>=13]["railway"="light_rail"],
   [zoom>=11]["railway"="tram"]["service"=null],
   [zoom>=13]["railway"="tram"] {
-    ["pzb"="no"]["lzb"="no"]["etcs"="no"]["construction_etcs"="no"],
-    ["atb"="no"]["etcs"="no"]["construction_etcs"="no"],
-    ["atc"="no"]["etcs"="no"]["construction_etcs"="no"],
-    ["kvb"="no"]["tvm"="no"]["etcs"="no"]["construction_etcs"="no"],
-    ["scmt"="no"]["etcs"="no"]["construction_etcs"="no"] {
+    ["rank"=1] {  /* shortcut: SQL functions set rank=1 for 'no protection' */
       line-color: @no_train_protection_color;
     }
     ["pzb"="yes"] {
@@ -104,7 +100,6 @@
     ["zsi127"="yes"] {
       line-color: @zsi127_color;
     }
-
     ["railway"="construction"] {
       line-dasharray: @construction_dashes;
     }


### PR DESCRIPTION
This PR is motivated by a discussion here:
https://github.com/OpenRailwayMap/OpenRailwayMap/issues/827
The idea is to simplify part of the code, concentrating the (complex) logic about detecting the lack of train protection in the SQL functions instead of duplicating it in the color-selecting code.

TESTS:

Ljubjiana on ORM:
![Screenshot from 2023-05-10 20-21-37](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/21276516/e8c4944d-96cc-4135-b33a-775c59030c67)

Ljubjiana on local Kosmtik after the changes:
![Screenshot from 2023-05-10 20-29-49](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/21276516/8458148b-52c4-40aa-85b3-01a9ddcd9e6c)
