### PR TITLE
Track gauge for Barcelona Metro lines

### DIFF
--- a/gauge.mss
+++ b/gauge.mss
@@ -408,11 +408,11 @@
       line-color: @color_gauge_1600;
     }
 
-    [gaugeint>=1668][gaugeint<1676] {
+    [gaugeint>=1668][gaugeint<1672] {
       line-color: @color_gauge_1668;
     }
 
-    [gaugeint>=1676][gaugeint<1700] {
+    [gaugeint>=1672][gaugeint<1700] {
       line-color: @color_gauge_1676;
     }
 


### PR DESCRIPTION
This is only a minimal change to distinguish the metro lines in Barcelona with gauge ~1674 from other nearby tracks with gauge 1668.