### PR TITLE
Add BOStrab g2a 5 km/h signal image

### DIFF
--- a/maxspeed_signals.mss
+++ b/maxspeed_signals.mss
@@ -664,10 +664,13 @@
 
     /* German tram speed limit signals as signs (G 2a) */
     ["feature"="DE-BOStrab:g2a"]["signal_speed_limit_form"="sign"] {
-      ["signal_speed_limit_speed"=~"^([1-3]5|[1-6]0)$"] {
+      ["signal_speed_limit_speed"=~"^([1-3]?5|[1-6]0)$"] {
         marker-allow-overlap: true;
         marker-width: 11;
         marker-height: 16;
+      }
+      ["signal_speed_limit_speed"="5"] {
+        marker-file: url('symbols/de/bostrab/g2a-5.svg');
       }
       ["signal_speed_limit_speed"="10"] {
         marker-file: url('symbols/de/bostrab/g2a-10.svg');

--- a/symbols/de/bostrab/g2a-5.svg
+++ b/symbols/de/bostrab/g2a-5.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="156.77524"
+   height="230.75842"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="g2a-05.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.1327203"
+     inkscape:cx="-172.15195"
+     inkscape:cy="138.16297"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer5"
+     showgrid="false"
+     inkscape:window-width="1707"
+     inkscape:window-height="995"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="schwarz"
+     transform="translate(-115.27474,107.26884)"
+     style="display:inline">
+    <rect
+       style="fill:#ffd815;fill-opacity:1;stroke:#ffffff;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4663"
+       width="140.77524"
+       height="214.75842"
+       x="123.27474"
+       y="-99.268845" />
+    <path
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.41389729"
+       d="m 212.7454,-63.837062 0,0.0713 -0.0121,0 0,8.977434 0.0121,0 0,26.907996 9.48339,0 c 0,-2.87173 2.92987,-3.712031 5.11493,-3.730216 2.9131,0 5.41392,1.731685 5.41392,4.358786 l -0.0849,14.175813 c 0,4.2049889 -1.40667,7.6405399 -5.21998,7.6432239 -3.81796,-0.0025 -5.46159,-2.636052 -5.46159,-7.6593979 l -9.23048,0 c 0,8.9814179 3.95901,17.1928029 14.69207,17.1958829 8.84482,-0.002 14.68965,-6.208317 14.68965,-13.811375 -0.0161,-5.9953069 0.0501,-11.9909759 -0.009,-17.9860889 -0.15291,-7.820657 -5.15768,-11.990209 -10.86444,-12.118752 -3.09861,0.0022 -6.75317,1.409638 -9.04008,3.478044 l 0,-18.453916 19.90452,0 0,-8.977434 -21.76068,0 0,-0.0713 -7.62723,0 z"
+       id="rect4407"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.700822"
+       d="m 171.50974,-39.466084 c -13.38243,0.07604 -26.77751,9.210813 -26.80012,27.182977 h -0.15764 v 74.252088 h 0.15764 c 0.33239,36.275967 53.55519,35.869685 53.57772,0 h 0.13512 v -74.252088 h -0.13512 c -0.0333,-18.267834 -13.40059,-27.258977 -26.7776,-27.182977 z m -0.0451,16.147634 c 5.65819,-0.05119 11.32716,3.578146 11.35064,11.035343 h -0.0451 v 74.252088 h 0.0676 c -0.0239,14.587381 -22.63372,14.616009 -22.63372,-0.337816 v -73.914272 h -0.0451 c 0.0238,-7.267065 5.65937,-10.984263 11.30559,-11.035343 z"
+       id="rect4094"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>


### PR DESCRIPTION
I created the SVG by mixing the existing 15 km/h sign with the 0 from the ESO-lf7 signs.

Example rendering in Nuremberg around Christuskirche.

![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/9f7183b9-5a20-49a6-9b1b-b7dc8e72fc5f)
