### PR TITLE
Add support for request signal on BOStrab:f signals

### DIFF
--- a/signals.mml
+++ b/signals.mml
@@ -294,7 +294,8 @@ Layer:
               tags->'railway:signal:crossing_distant',
               tags->'railway:signal:crossing',
               tags->'railway:signal:ring',
-              tags->'railway:signal:whistle'
+              tags->'railway:signal:whistle',
+              tags->'railway:signal:request'
             ) AS feature,
             tags->'railway:signal:passing:caption' AS passing_caption,
             tags->'railway:signal:stop:caption' AS stop_caption,
@@ -330,6 +331,7 @@ Layer:
             tags->'railway:signal:crossing:form' AS crossing_form,
             tags->'railway:signal:ring:form' AS ring_form,
             tags->'railway:signal:whistle:form' AS whistle_form,
+            tags->'railway:signal:request:form' AS request_form,
             tags->'railway:signal:combined:height' AS combined_height,
             tags->'railway:signal:main:height' AS main_height,
             tags->'railway:signal:distant:height' AS distant_height,
@@ -358,6 +360,7 @@ Layer:
             tags->'railway:signal:crossing:states' AS crossing_states,
             tags->'railway:signal:ring:states' AS ring_states,
             tags->'railway:signal:whistle:states' AS whistle_states,
+            tags->'railway:signal:request:states' AS request_states,
             tags->'railway:signal:combined:repeated' AS combined_repeated,
             tags->'railway:signal:main:repeated' AS main_repeated,
             tags->'railway:signal:distant:repeated' AS distant_repeated,

--- a/signals.mss
+++ b/signals.mss
@@ -1216,6 +1216,13 @@ Format details:
     ["feature"="DE-BOStrab:f"]["main_form"="light"]["main_states"=~"^(.*;)?DE-BOStrab:f1(;.*)?$"],
     ["feature"="DE-AVG:f"]["main_form"="light"]["main_states"=~"^(.*;)?DE-AVG:f1(;.*)?$"] {
       marker-file: url('symbols/de/bostrab/f1.svg');
+
+      /* can display St 9 */
+      ["request_form"="light"]["request_states"=~"^(.*;)?DE-VBK:st9(;.*)?$"] {
+        marker-width: 10;
+        marker-height: 30;
+        marker-file: url('symbols/de/bostrab/f1-st9.svg');
+      }
     }
 
     /************************************/
@@ -1224,7 +1231,13 @@ Format details:
     /************************************/
     ["feature"="DE-BOStrab:f"]["main_form"="light"]["main_states"=~"^(.*;)?DE-BOStrab:f2(;.*)?$"],
     ["feature"="DE-AVG:f"]["main_form"="light"]["main_states"=~"^(.*;)?DE-AVG:f2(;.*)?$"] {
-      marker-file: url('symbols/de/bostrab/f2.svg');
+
+      /* can display St 9 */
+      ["request_form"="light"]["request_states"=~"^(.*;)?DE-VBK:st9(;.*)?$"] {
+        marker-width: 10;
+        marker-height: 30;
+        marker-file: url('symbols/de/bostrab/f2-st9.svg');
+      }
     }
 
     /************************************/
@@ -1234,6 +1247,14 @@ Format details:
     ["feature"="DE-BOStrab:f"]["main_form"="light"]["main_states"=~"^(.*;)?DE-BOStrab:f3(;.*)?$"],
     ["feature"="DE-AVG:f"]["main_form"="light"]["main_states"=~"^(.*;)?DE-AVG:f3(;.*)?$"] {
       marker-file: url('symbols/de/bostrab/f3.svg');
+
+      /* can display St 9 */
+      ["request_form"="light"]["request_states"=~"^(.*;)?DE-VBK:st9(;.*)?$"] {
+        marker-width: 10;
+        marker-height: 30;
+        marker-file: url('symbols/de/bostrab/f3-st9.svg');
+      }
+    }
     }
   }
 

--- a/symbols/de/bostrab/f1-st9.svg
+++ b/symbols/de/bostrab/f1-st9.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="48"
+   viewBox="0 0 16 48.000001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="f1-st9.svg"
+   inkscape:export-filename="/home/michael/Entwicklung/OpenRailwayMap/styles/icons/de/bostrab/f1-32.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="0"
+     inkscape:cy="18.24588"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1707"
+     inkscape:window-height="995"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1020.3622)">
+    <rect
+       style="opacity:1;fill:#838383;fill-opacity:1;stroke:none;stroke-width:2.44949;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4136"
+       width="16"
+       height="48"
+       x="0"
+       y="1020.3622" />
+    <circle
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4138"
+       cx="8"
+       cy="1044.3622"
+       r="7" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4140"
+       width="3.0803571"
+       height="10.267858"
+       x="6.6294641"
+       y="1039.4158" />
+    <circle
+       r="7"
+       cy="-8"
+       cx="1028.3622"
+       id="circle4207"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="rotate(90)" />
+    <circle
+       r="7"
+       cy="-8"
+       cx="1060.3622"
+       id="circle4207-3"
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="rotate(90)" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       d="M 6.450329,1055.6622 3.402,1063.8433 h 1.858906 l 0.952459,-2.2684 h 3.57057 l 0.952459,2.2684 H 12.5976 l -3.050629,-8.1811 z m 1.548321,1.6681 1.003073,2.3857 H 6.995577 Z"
+       id="path4206"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+  </g>
+</svg>

--- a/symbols/de/bostrab/f2-st9.svg
+++ b/symbols/de/bostrab/f2-st9.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="48"
+   viewBox="0 0 16 48.000001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="f2-st9.svg"
+   inkscape:export-filename="/home/michael/Entwicklung/OpenRailwayMap/styles/icons/de/bostrab/f1-32.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="0"
+     inkscape:cy="18.24588"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1707"
+     inkscape:window-height="995"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1020.3622)">
+    <rect
+       style="opacity:1;fill:#838383;fill-opacity:1;stroke:none;stroke-width:2.44949;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4136"
+       width="16"
+       height="48"
+       x="0"
+       y="1020.3622" />
+    <circle
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4138"
+       cx="8"
+       cy="1044.3622"
+       r="7" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4140-6"
+       width="3.0803571"
+       height="10.267858"
+       x="907.15173"
+       y="510.06549"
+       transform="rotate(60)" />
+    <circle
+       r="7"
+       cy="-8"
+       cx="1028.3622"
+       id="circle4207"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="rotate(90)" />
+    <circle
+       r="7"
+       cy="-8"
+       cx="1060.3622"
+       id="circle4207-3"
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="rotate(90)" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       d="M 6.450329,1055.6622 3.402,1063.8433 h 1.858906 l 0.952459,-2.2684 h 3.57057 l 0.952459,2.2684 H 12.5976 l -3.050629,-8.1811 z m 1.548321,1.6681 1.003073,2.3857 H 6.995577 Z"
+       id="path4206"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+  </g>
+</svg>

--- a/symbols/de/bostrab/f3-st9.svg
+++ b/symbols/de/bostrab/f3-st9.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="48"
+   viewBox="0 0 16 48.000001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="f3-st9.svg"
+   inkscape:export-filename="/home/michael/Entwicklung/OpenRailwayMap/styles/icons/de/bostrab/f1-32.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="-6.0609153"
+     inkscape:cy="14.457808"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1707"
+     inkscape:window-height="995"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1020.3622)">
+    <rect
+       style="opacity:1;fill:#838383;fill-opacity:1;stroke:none;stroke-width:2.44949;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4136"
+       width="16"
+       height="48"
+       x="0"
+       y="1020.3622" />
+    <circle
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4138"
+       cx="8"
+       cy="1044.3622"
+       r="7" />
+    <circle
+       r="7"
+       cy="-8"
+       cx="1028.3622"
+       id="circle4207"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="rotate(90)" />
+    <circle
+       r="7"
+       cy="-8"
+       cx="1060.3622"
+       id="circle4207-3"
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="rotate(90)" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       d="M 6.450329,1055.6622 3.402,1063.8433 h 1.858906 l 0.952459,-2.2684 h 3.57057 l 0.952459,2.2684 H 12.5976 l -3.050629,-8.1811 z m 1.548321,1.6681 1.003073,2.3857 H 6.995577 Z"
+       id="path4206"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4140"
+       width="3.0803571"
+       height="10.267858"
+       x="-902.06189"
+       y="524.21667"
+       transform="rotate(-60)" />
+  </g>
+</svg>


### PR DESCRIPTION
The approach is pretty terrible, so I'm open for improvements.

Example rendering in Karlsruhe around Durlacher Tor.

![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/33c730b7-ce55-4df7-b75c-42f047af8026)

Also I'd like to add support for more common combinations, like (pseudo-regex):
`F0 [F4]? [F1-3|F5] [A1]? [St9]?`

So, most likely these:
- F0 F4 F1
- F0 F4 F2
- F0 F4 F3
- F0 F4 F5
- F0 F1 A1
- F0 F2 A1
- F0 F3 A1
- F0 F4 F1 A1
- F0 F4 F2 A1
- F0 F4 F3 A1
- F0 F4 F1 St9
- F0 F4 F2 St9
- F0 F4 F3 St9
- F0 F4 F1 A1 St9
- F0 F4 F2 A1 St9
- F0 F4 F3 A1 St9