### PR TITLE
Add support for the BOStrab F5 signal

### DIFF
--- a/signals.mss
+++ b/signals.mss
@@ -1235,6 +1235,14 @@ Format details:
     ["feature"="DE-AVG:f"]["main_form"="light"]["main_states"=~"^(.*;)?DE-AVG:f3(;.*)?$"] {
       marker-file: url('symbols/de/bostrab/f3.svg');
     }
+
+    /************************************/
+    /* DE tram main signal "Fahrsignal" */
+    /* can show F 5 (permissive)        */
+    /************************************/
+    ["main_states"=~"^(.*;)?(DE-BOStrab|DE-AVG):f5(;.*)?$"] {
+      marker-file: url('symbols/de/bostrab/f5.svg');
+    }
   }
 
   /****************************************/

--- a/symbols/de/bostrab/f5.svg
+++ b/symbols/de/bostrab/f5.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="32"
+   viewBox="0 0 16 32.000001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="f5.svg"
+   inkscape:export-filename="/home/michael/Entwicklung/OpenRailwayMap/styles/icons/de/bostrab/f3-32.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16.96875"
+     inkscape:cx="-4.3020258"
+     inkscape:cy="13.996317"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1707"
+     inkscape:window-height="995"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1020.3622)">
+    <rect
+       style="opacity:1;fill:#838383;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4136"
+       width="16"
+       height="32"
+       x="0"
+       y="1020.3622" />
+    <circle
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4138"
+       cx="8"
+       cy="1044.3622"
+       r="7" />
+    <circle
+       r="7"
+       cy="-8"
+       cx="1028.3622"
+       id="circle4207"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff"
+       id="path1"
+       inkscape:flatsided="false"
+       sodipodi:sides="3"
+       sodipodi:cx="3.5948434"
+       sodipodi:cy="20.331491"
+       sodipodi:r1="5.9896345"
+       sodipodi:r2="2.994817"
+       sodipodi:arg1="0.52359878"
+       sodipodi:arg2="1.5707963"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 8.782019,23.326309 -5.1871755,-10e-7 -5.1871758,10e-7 2.593588,-4.492226 2.5935877,-4.492226 2.5935876,4.492226 z"
+       transform="matrix(0.46392376,0.80353953,-0.80353953,0.46392376,22.722411,1032.0463)"
+       inkscape:transform-center-y="1.3893495"
+       inkscape:transform-center-x="-1.8164773e-06" />
+  </g>
+</svg>


### PR DESCRIPTION
Example rendering in Nuremberg around Steinbühl

![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/c84f460d-56eb-4a2e-8ac9-5b0ba84a88fc)


