### PR TITLE
Fix shortened BÜ2 not rendering

### DIFF
--- a/signals.mml
+++ b/signals.mml
@@ -382,7 +382,7 @@ Layer:
             tags->'railway:signal:stop:shortened' AS stop_shortened,
             tags->'railway:signal:stop_demand:shortened' AS stop_demand_shortened,
             tags->'railway:signal:station:distant:shortened' AS station_distant_shortened,
-            tags->'railway:signal:crossing:distant:shortened' AS crossing_distant_shortened,
+            tags->'railway:signal:crossing_distant:shortened' AS crossing_distant_shortened,
             tags->'railway:signal:crossing:shortened' AS crossing_shortened,
             tags->'railway:signal:ring:shortened' AS ring_shortened,
             tags->'railway:signal:whistle:shortened' AS whistle_shortened,


### PR DESCRIPTION
This happens because we query for the wrong tag.

Wrong:
`railway:signal:crossing:distant:shortened=yes`
Correct:
`railway:signal:crossing_distant:shortened=yes`

See also: https://overpass-turbo.eu/s/1DBg

Example rendering 
![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/32600731-2341-46a5-b2d3-5ae174b766da)
