### PR TITLE
Fix Bü4 and Pf1 only transit not rendering

### DIFF
--- a/signals.mss
+++ b/signals.mss
@@ -44,7 +44,7 @@ Format details:
     marker-allow-overlap: true;
 
     /* for trains not stopping at a halt */
-    ["ring_only_transit"="yes"] {
+    ["whistle_only_transit"="yes"] {
       marker-file: url('symbols/de/bue4-ds-only-transit.svg');
       marker-width: 12;
       marker-height: 21;
@@ -61,7 +61,7 @@ Format details:
     marker-allow-overlap: true;
 
     /* DE whistle sign Pf 1 (DV 301) for trains not stopping at a halt */
-    ["ring_only_transit"="yes"] {
+    ["whistle_only_transit"="yes"] {
       marker-file: url('symbols/de/pf1-dv-only-transit.svg');
       marker-width: 12;
       marker-height: 21;


### PR DESCRIPTION
Seems like a copy paste error to me, example renderings:

Fürth-Westvorstadt:
![Screenshot_20231119_162020](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/597e155f-4157-4ccc-a997-17dd4ec052d7)

Around Ernstthal am Rennsteig:
![Screenshot_20231119_162222](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/8429cd5c-de4e-4dff-b270-48002b17baa0)
