### PR TITLE
Add rendering for ESO Bü3 sign

### DIFF
--- a/signals.mss
+++ b/signals.mss
@@ -35,6 +35,16 @@ Format details:
   }
 
   /*********************************/
+  /* DE crossing distant sign Bü 3 */
+  /*********************************/
+  [zoom>=15]["feature"="DE-ESO:bü3"] {
+    marker-file: url('symbols/de/bue3.svg');
+    marker-width: 5.5;
+    marker-height: 26;
+    marker-allow-overlap: true;
+  }
+
+  /*********************************/
   /* DE whistle sign Bü 4 (DS 301) */
   /*********************************/
   ["feature"="DE-ESO:db:bü4"] {


### PR DESCRIPTION
Example rendering north west of Treuchtlingen:

![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/75f1b369-0ce5-463f-9a13-549eaa9d961e)
