### PR TITLE
Ne13 and Ne12 rendering

### DIFF
--- a/signals.mml
+++ b/signals.mml
@@ -295,7 +295,8 @@ Layer:
               tags->'railway:signal:crossing',
               tags->'railway:signal:ring',
               tags->'railway:signal:whistle',
-              tags->'railway:signal:resetting_switch'
+              tags->'railway:signal:resetting_switch',
+              tags->'railway:signal:resetting_switch_distant'
             ) AS feature,
             tags->'railway:signal:passing:caption' AS passing_caption,
             tags->'railway:signal:stop:caption' AS stop_caption,
@@ -416,7 +417,8 @@ Layer:
             tags->'railway:signal:ring:type' AS ring_type,
             tags->'railway:signal:whistle:type' AS whistle_type,
             tags->'railway:signal:train_protection:shape' AS train_protection_shape,
-            tags->'railway:signal:resetting_switch:form' AS resetting_switch_form
+            tags->'railway:signal:resetting_switch:form' AS resetting_switch_form,
+            tags->'railway:signal:resetting_switch_distant:form' AS resetting_switch_distant_form
           FROM openrailwaymap_osm_signals
           WHERE
             (railway IN ('signal', 'buffer_stop') AND "signal_direction" IS NOT NULL)

--- a/signals.mml
+++ b/signals.mml
@@ -294,7 +294,8 @@ Layer:
               tags->'railway:signal:crossing_distant',
               tags->'railway:signal:crossing',
               tags->'railway:signal:ring',
-              tags->'railway:signal:whistle'
+              tags->'railway:signal:whistle',
+              tags->'railway:signal:resetting_switch'
             ) AS feature,
             tags->'railway:signal:passing:caption' AS passing_caption,
             tags->'railway:signal:stop:caption' AS stop_caption,
@@ -414,7 +415,8 @@ Layer:
             tags->'railway:signal:crossing:type' AS crossing_type,
             tags->'railway:signal:ring:type' AS ring_type,
             tags->'railway:signal:whistle:type' AS whistle_type,
-            tags->'railway:signal:train_protection:shape' AS train_protection_shape
+            tags->'railway:signal:train_protection:shape' AS train_protection_shape,
+            tags->'railway:signal:resetting_switch:form' AS resetting_switch_form
           FROM openrailwaymap_osm_signals
           WHERE
             (railway IN ('signal', 'buffer_stop') AND "signal_direction" IS NOT NULL)

--- a/signals.mss
+++ b/signals.mss
@@ -704,6 +704,16 @@ Format details:
     }
   }
 
+  /*******************************************/
+  /* DE Ne12 resetting switch distant signal */
+  /*******************************************/
+  [zoom>=17]["feature"="DE-ESO:ne12"]["resetting_switch_distant_form"="sign"] {
+    marker-file: url('symbols/de/ne12.svg');
+    marker-width: 5.5;
+    marker-height: 26;
+    marker-allow-overlap: true;
+  }
+
   /***********************************/
   /* DE Ne13 resetting switch signal */
   /***********************************/

--- a/signals.mss
+++ b/signals.mss
@@ -704,6 +704,16 @@ Format details:
     }
   }
 
+  /***********************************/
+  /* DE Ne13 resetting switch signal */
+  /***********************************/
+  [zoom>=17]["feature"="DE-ESO:ne13"]["resetting_switch_form"="light"] {
+    marker-file: url('symbols/de/ne13a.svg');
+    marker-width: 12;
+    marker-height: 8;
+    marker-allow-overlap: true;
+  }
+
   /************************************/
   /* DE ETCS stop marker              */
   /* NL ETCS stopplaatsmarkering 227b */


### PR DESCRIPTION
Very straightforward, example in Rauenstein (Thür):

![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/124ca7ff-bbe5-471d-b159-6a3c5abc9bc6)
