### PR TITLE
Fix ESO Blockkennzeichen rendering issues

### DIFF
--- a/signals.mss
+++ b/signals.mss
@@ -682,19 +682,23 @@ Format details:
   /* DE block marker ("Blockkennzeichen) */
   /***************************************/
   ["feature"="DE-ESO:blockkennzeichen"] {
-    [zoom<16],
-    [zoom>=16][zoom<17][height > 1],
-    [zoom>=16][zoom<17][width > 2],
-    [zoom>=17][height > 2],
-    [zoom>=17][width > 4] {
       marker-file: url('symbols/de/blockkennzeichen.svg');
       marker-allow-overlap: true;
       marker-width: 14;
       marker-height: 14;
+
+    ::text {
+      text-name: [ref];
+      text-dy: 10;
+      text-fill: @signal-text-fill;
+      text-halo-radius: @signal-text-halo-radius;
+      text-halo-fill: @signal-text-halo-fill;
+      text-face-name: @bold-fonts;
+      text-size: 10;
     }
 
-    [zoom>=16][height <= 1][width <= 2],
-    [zoom>=17][height <= 2][width <= 4] {
+    [zoom=16][height<=1][width<=2],
+    [zoom>=17][height<=2][width<=4] {
       shield-file: url('symbols/flex/de/blockkennzeichen-[width]x[height].svg');
       shield-name: [ref_multiline];
       shield-fill: black;


### PR DESCRIPTION
Fixes #50 

I simplified the code to make use of the implicit else CartoCSS has. Additionally, the Blockkennzeichen is now showing it's ref like a normal signal if not using the flex shied container. (I hope that's okay)

Example renderings at the location mentioned in the issue:

Zoom 15:
![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/c3734613-9abf-42f4-9cbd-171f1d5c0b78)

Zoom 16:
![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/bdfbafa4-d5ca-410f-a7ce-b8e660837b03)

Zoom 17:
![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/10588728/fb3d34bc-ad84-4a34-97a1-5481247111d8)
