### PR TITLE
add BOStrab combined signals

### DIFF
--- a/signals.mss
+++ b/signals.mss
@@ -1279,6 +1279,26 @@ Format details:
     }
   }
 
+  /***********************************************************/
+  /* DE BOStrab combined signals - similar to EBO Ks signals */
+  /***********************************************************/
+  [zoom>=15]["feature"="DE-BOStrab:h"] {
+      marker-file: url('symbols/de/ks-combined.svg');
+      marker-width: 10;
+      marker-height: 16;
+      marker-allow-overlap: true;
+
+    ::text {
+      text-name: [ref];
+      text-dy: 16;
+      text-fill: @signal-text-fill;
+      text-halo-radius: @signal-text-halo-radius;
+      text-halo-fill: @signal-text-halo-fill;
+      text-face-name: @bold-fonts;
+      text-size: 10;
+    }
+  }
+
   /****************************************/
   /* DE Hamburger Hochbahn main signal    */
   /****************************************/


### PR DESCRIPTION
I have added the rendering of BOStrab train control signals in this PR. These are similar to the DE-EBO Ks signal system, so I simply used the existing SVG. Is that ok?

## Example Karlsruhe Stadtbahntunnel
### Zoom level 14
(The two signals you can see are incorrectly tagged in OSM as "Ks signals")
![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/4103693/d503aabc-03cb-4d84-ab76-a5709f5fb684)

### Zoom level 15
![image](https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/assets/4103693/f2ab7c89-0e58-46c5-aced-080ca651dc15)
